### PR TITLE
Overhaul status javadoc

### DIFF
--- a/src/battle/Status.java
+++ b/src/battle/Status.java
@@ -78,30 +78,23 @@ public class Status implements TurnItem {
   private final boolean defeating;
 
   /**
-   * States whether or not the status should be visible to the user of the
-   * client.
+   * @see StatusBuilder#setHidden(boolean)
    */
   private final boolean hidden;
 
   /**
-   * Test condition that returns true if the status can be successfully applied
-   * to the target owner of the status. Accepts the target owner of the status 
-   * as the given parameter. Attempting to initiate the value as {@code null}
-   * will throw an {@link IllegalArgumentException}.
+   * @see StatusBuilder#setApplyCondition(java.util.function.Predicate)
    */
   private final Predicate<Fighter> applyCondition;
 
   /**
-   * Test condition that returns true if the status can be successfully removed
-   * from the owner of the status. Accepts the owner of the status as the given
-   * parameter. Attempting to initiate the value as {@code null} will throw an
-   * {@link IllegalArgumentException}.
+   * @see StatusBuilder#setRemoveCondition(java.util.function.Predicate)
    */
 
   private final Predicate<Fighter> removeCondition;
+  
   /**
-   * List of handler objects that who's methods are called during appropriate
-   * state changes in the Status object.
+   * @see StatusBuilder#addListener(battle.StatusHandler)
    */
   private final Set<StatusHandler> listeners;
 
@@ -137,20 +130,20 @@ public class Status implements TurnItem {
    * explicitly set are done so through the given parameters. See the {@link 
    * StatusBuilder} class which allows you to create Status object using a
    * builder pattern.
-   * @param name {@see #name}
-   * @param description {@see #description}
-   * @param duration {@see #duration}
-   * @param stackSize {@see #stackSize}
-   * @param stacks {@see #stacks}
-   * @param stuns {@see #stuns}
-   * @param defeats {@see #defeats}
-   * @param hidden {@see #hidden}
-   * @param applyCondition {@see #applyCondition}
-   * @param removeCondition {@see #removeCondition}
-   * @param listeners {@see #listeners}
+   * @param name {@see StatusBuilder#setName}
+   * @param description {@see StatusBuilder#setDescription}
+   * @param duration {@see StatusBuilder#setDuration}
+   * @param stackSize {@see StatusBuilder#setStackSize}
+   * @param stackable {@see StatusBuilder#setStackable}
+   * @param stunning {@see StatusBuilder#setStunning}
+   * @param defeating {@see StatusBuilder#setDefeating}
+   * @param hidden {@see StatusBuilder#setHidden}
+   * @param applyCondition {@see StatusBuilder#setApplyCondition}
+   * @param removeCondition {@see StatusBuilder#setRemoveCondition}
+   * @param listeners {@see StatusBuilder#addListener}
    */
   protected Status(String name, String description, Duration duration,
-      int stackSize, boolean stacks, boolean stuns, boolean defeats,
+      int stackSize, boolean stackable, boolean stunning, boolean defeating,
       boolean hidden, Predicate<Fighter> applyCondition, Predicate<Fighter>
       removeCondition, List<StatusHandler> listeners) {
     if (name == null) {
@@ -169,9 +162,9 @@ public class Status implements TurnItem {
       throw new IllegalArgumentException("stacks cannot be negative");
     }
     this.stackSize = stackSize;
-    this.stackable = stacks;
-    this.stunning = stuns;
-    this.defeating = defeats;
+    this.stackable = stackable;
+    this.stunning = stunning;
+    this.defeating = defeating;
     this.hidden = hidden;
     if (applyCondition == null) {
       throw new IllegalArgumentException("Condition for application cannot be"
@@ -363,9 +356,9 @@ public class Status implements TurnItem {
   }
   
   /**
-   * Adds to the list of handler objects that who's methods are called during
-   * appropriate state changes in the Status object.
-   * @param listener object to handle state changes.
+   * Adds to the list of {@link StatusHandler} objects that are called during
+   * appropriate events in the Status object.
+   * @param listener object to handle events.
    */
   public final void addListener(StatusHandler listener) {
     if (listener == null) {
@@ -375,38 +368,35 @@ public class Status implements TurnItem {
   }
   
   /**
-   * Removes a handler object from the list of listeners who's methods are
-   * called during appropriate state changes in the Status object.
+   * Removes a listener from the list of {@link StatusHandler} objects that are
+   * called during appropriate events in the Status object.
    * @param listener the object to be removed.
    * @return true if the object was successfully removed.
+   * @see #addListener(battle.StatusHandler)
    */
   public final boolean removeListener(StatusHandler listener) {
     return this.listeners.remove(listener);
   }
   
   /**
-   * Name of the status. Identifies the status from unrelated Status objects.
    * @return name of the Status.
+   * @see StatusBuilder#setName
    */
   public final String getName() {
     return name;
   }
 
   /**
-   * Returns a description of the status and how it is intended to interact with
-   * Fighter objects it is applied to, as well as its interactions with other
-   * Status objects on the same fighter.
-   * @return description of the status
+   * @return description of the status.
+   * @see StatusBuilder#setDescription
    */
   public final String getDescription() {
     return description;
   }
 
   /**
-   * The time before this status expires. Zero means the Status has an instant
-   * duration and should expire as soon as it is applied. Less then zero means
-   * duration is infinite.
    * @return time before the status expires.
+   * @see StatusBuilder#setDuration
    */
   public final Duration getDuration() {
     if (stackList.isEmpty()) return Duration.ZERO;
@@ -420,8 +410,8 @@ public class Status implements TurnItem {
   }
 
   /**
-   * The current number of stacks.
-   * @return stack size.
+   * @return the current stack size.
+   * @see StatusBuilder#setStackSize
    */
   public final int getStackSize() {
     int currentSize = 0;
@@ -440,45 +430,41 @@ public class Status implements TurnItem {
   }
   
   /**
-   * Returns true if the status increases in stack size when equivalent Status
-   * objects are added to it.
-   * @return true if this is stacks.
+   * @return {@code true} if the status is stackable.
+   * @see StatusBuilder#setStackable
    */
   public final boolean isStackable() {
     return stackable;
   }
   
   /**
-   * Returns true if this status stuns the fighter. Stunned fighters do not
-   * decrement their skill cooldowns and cannot execute skills.
-   * @return true if the Status stuns the Unit it is applied to.
+   * @return {@code true} if the status stuns the fighter it is applied to.
+   * @see StatusBuilder#setStunning
    */
   public final boolean isStunning() {
     return stunning;
   }
 
   /**
-   * Returns true if the Status object defeats the fighter. Defeated Fighter
-   * objects allow their team to lose a battle if all other ally fighters are
-   * also defeated.
-   * @return true if this defeats the fighter it is applied to.
+   * @return {@code true} if the status defeats the fighter it is applied to.
+   * @see StatusBuilder#setDefeating
    */
   public final boolean isDefeating() {
     return defeating;
   }
   
   /**
-   * Returns true is the status should be hidden from client users.
-   * @return true if this is hidden from user.
+   * @return {@code true} if the status should be hidden from user.
+   * @see StatusBuilder#setHidden
    */
   public final boolean isHidden() {
     return hidden;
   }
 
   /**
-   * Returns {@code true} if the status should be removed as soon as it is
-   * applied. This is indicated my setting the duration value to {@code ZERO}.
-   * @return true if this is an instant status.
+   * Returns {@code true} if the status has a finite duration and does not
+   * expire instantly.
+   * @return {@code true} if this is a finite status.
    */
   public final boolean isFinite() {
     return !isInfinite() && !isInstant();
@@ -486,9 +472,8 @@ public class Status implements TurnItem {
   
   /**
    * Returns {@code true} if the status should be unable to expire due to
-   * passing time. This is indicated my setting the duration value to a
-   * negative value.
-   * @return true if this is an instant status.
+   * passing time.
+   * @return {@code true} if this is an infinite status.
    */
   public final boolean isInfinite() {
     return this.duration.isNegative();
@@ -496,8 +481,8 @@ public class Status implements TurnItem {
   
   /**
    * Returns {@code true} if the status should be removed as soon as it is
-   * applied. This is indicated my setting the duration value to {@code ZERO}.
-   * @return true if this is an instant status.
+   * applied.
+   * @return {@code true} if this is an instant status.
    */
   public final boolean isInstant() {
     return this.duration.isZero();

--- a/src/battle/Status.java
+++ b/src/battle/Status.java
@@ -43,52 +43,39 @@ import java.util.function.Predicate;
 public class Status implements TurnItem {
   
   /**
-   * Name of the status. Identifies the status from unrelated Status objects.
-   * Attempting to initiate the value as {@code null} will throw an {@link
-   * IllegalArgumentException}.
+   * @see StatusBuilder#setName(java.lang.String)
    */
   private final String name;
 
   /**
-   * Description of the status and how it is intended to interact with
-   * Fighter objects it is applied to, as well as its interactions with other
-   * Status objects on the same fighter. Attempting to initiate the value as
-   * {@code null} will throw an {@link IllegalArgumentException}.
+   * @see StatusBuilder#setDescription(java.lang.String)
    */
   private final String description;
 
   /**
-   * The time before this status expires once it is applied. Zero means the
-   * Status has an instant duration and should expire as soon as it is applied.
-   * Less then zero means duration is infinite. Attempting to initiate the value
-   * as {@code null} will throw an {@link IllegalArgumentException}.
+   * @see StatusBuilder#setDuration(java.time.Duration)
    */
   private final Duration duration;
 
   /**
-   * The current number of stacks. Attempting to initiate the value as less then
-   * {@code 1} will throw an {@link IllegalArgumentException}.
+   * @see StatusBuilder#setStackSize(int)
    */
   private final int stackSize;
 
   /**
-   * States whether the status increases in stack size when equivalent Status
-   * objects are combined with it.
+   * @see StatusBuilder#setStackable(boolean)
    */
-  private final boolean stacks;
+  private final boolean stackable;
 
   /**
-   * States whether or not this status stuns the fighter. Stunned fighters do
-   * not decrement their skill cooldowns and cannot execute skills.
+   * @see StatusBuilder#setStunning(boolean)
    */
-  private final boolean stuns;
+  private final boolean stunning;
 
   /**
-   * States whether or not the Status object defeats the fighter. Defeated
-   * Fighter objects allow their team to lose a battle if all other ally
-   * fighters are also defeated.
+   * @see StatusBuilder#setDefeating(boolean)
    */
-  private final boolean defeats;
+  private final boolean defeating;
 
   /**
    * States whether or not the status should be visible to the user of the
@@ -182,9 +169,9 @@ public class Status implements TurnItem {
       throw new IllegalArgumentException("stacks cannot be negative");
     }
     this.stackSize = stackSize;
-    this.stacks = stacks;
-    this.stuns = stuns;
-    this.defeats = defeats;
+    this.stackable = stacks;
+    this.stunning = stuns;
+    this.defeating = defeats;
     this.hidden = hidden;
     if (applyCondition == null) {
       throw new IllegalArgumentException("Condition for application cannot be"
@@ -223,9 +210,9 @@ public class Status implements TurnItem {
     this.description = copyOf.description;
     this.duration = copyOf.duration;
     this.stackSize = copyOf.stackSize;
-    this.stacks = copyOf.stacks;
-    this.stuns = copyOf.stuns;
-    this.defeats = copyOf.defeats;
+    this.stackable = copyOf.stackable;
+    this.stunning = copyOf.stunning;
+    this.defeating = copyOf.defeating;
     this.hidden = copyOf.hidden;
     this.applyCondition = copyOf.applyCondition;
     this.removeCondition = copyOf.removeCondition;
@@ -277,9 +264,9 @@ public class Status implements TurnItem {
   public final boolean canCombine(Status status) {
     return (status != null) &&
         status.name.equals(name) &&
-        (status.stacks == this.stacks) &&
-        (status.defeats == this.defeats) &&
-        (status.stuns == this.stuns) &&
+        (status.stackable == this.stackable) &&
+        (status.defeating == this.defeating) &&
+        (status.stunning == this.stunning) &&
         (status.hidden == this.hidden) &&
         ((status.isInstant() == status.isInstant()) ||
         (status.isFinite() == this.isFinite()) ||
@@ -458,7 +445,7 @@ public class Status implements TurnItem {
    * @return true if this is stacks.
    */
   public final boolean isStackable() {
-    return stacks;
+    return stackable;
   }
   
   /**
@@ -467,7 +454,7 @@ public class Status implements TurnItem {
    * @return true if the Status stuns the Unit it is applied to.
    */
   public final boolean isStunning() {
-    return stuns;
+    return stunning;
   }
 
   /**
@@ -477,7 +464,7 @@ public class Status implements TurnItem {
    * @return true if this defeats the fighter it is applied to.
    */
   public final boolean isDefeating() {
-    return defeats;
+    return defeating;
   }
   
   /**

--- a/src/battle/StatusBuilder.java
+++ b/src/battle/StatusBuilder.java
@@ -251,7 +251,7 @@ public class StatusBuilder {
   }
 
   /**
-   * Sets the status to be built to that it can defeat the fighter it is applied
+   * Sets the status to be built so that it can defeat the fighter it is applied
    * to. Defeated {@link Fighter} objects allow their team to lose a battle if
    * all other ally fighters are also defeated. Defeated fighters do not
    * decrement their skill cooldowns or execute skills for non-deathless skills.
@@ -266,10 +266,10 @@ public class StatusBuilder {
   }
 
   /**
-   * @param hidden hidden value for producing a Status object. The default value
-   * is {@code false}.
-   * @return this.
-   * @see battle.Status Status.hidden
+   * Sets the status to be built so that it should not be visible to the user of
+   * the client. The default value is {@code false}.
+   * @param hidden allows the status to be hidden when {@code true}.
+   * @return this object.
    */
   public StatusBuilder setHidden(boolean hidden) {
     this.hidden = hidden;
@@ -277,10 +277,15 @@ public class StatusBuilder {
   }
   
   /**
-   * @param applyCondition applyCondtion value for producing a Status object.
-   * The default value is a function that returns {@code true}.
-   * @return this.
-   * @see battle.Status Status.applyCondition
+   * Sets the test condition that returns {@code true} if the status can be
+   * successfully applied to the target owner of the status to be built. Accepts
+   * the target owner of the status as the given parameter. Attempting to
+   * initiate the value as {@code null} will throw an {@link
+   * IllegalArgumentException}. The default value is a function that returns
+   * {@code true}.
+   * @param applyCondition functional interface that returns {@code true} when
+   *        the status can be applied.
+   * @return this object.
    */
   public StatusBuilder setApplyCondition(Predicate<Fighter> applyCondition) {
     if (applyCondition == null) {
@@ -292,10 +297,14 @@ public class StatusBuilder {
   }
 
   /**
-   * @param removeCondition removeCondition value for producing a Status object.
+   * Sets the test condition that returns {@code true} if the status can be
+   * successfully removed from the owner of the status to be built. Accepts
+   * the owner of the status as the given parameter. Attempting to initiate
+   * the value as {@code null} will throw an {@link IllegalArgumentException}.
    * The default value is a function that returns {@code true}.
-   * @return this.
-   * @see battle.Status Status.removeCondition
+   * @param removeCondition functional interface that returns {@code true} when
+   *        the status can be removed.
+   * @return this object.
    */
   public StatusBuilder setRemoveCondition(Predicate<Fighter> removeCondition) {
     if (removeCondition == null) {
@@ -307,11 +316,10 @@ public class StatusBuilder {
   }
   
   /**
-   * Adds to the list of handler objects that who's methods are called during
-   * appropriate state changes in the Status object.
-   * @param  listener object to handle state changes.
-   * @return this.
-   * @see battle.Status Status.listeners
+   * Adds to the list of {@link StatusHandler} objects that are called during
+   * appropriate events in the Status object.
+   * @param  listener object to handle events.
+   * @return this object.
    */
   public StatusBuilder addListener(StatusHandler listener) {
     if (listener == null) {
@@ -322,11 +330,11 @@ public class StatusBuilder {
   }
   
   /**
-   * Removes a handler object from the list of listeners who's methods are
-   * called during appropriate state changes in the Status object.
+   * Removes a listener from the list of {@link StatusHandler} objects that are
+   * called during appropriate events in the Status object.
    * @param  listener the object to be removed.
    * @return true if the object was successfully removed.
-   * @see battle.Status Status.listeners
+   * @see #addListener(battle.StatusHandler)
    */
   public boolean removeListener(StatusHandler listener) {
     return this.listeners.remove(listener);

--- a/src/battle/StatusBuilder.java
+++ b/src/battle/StatusBuilder.java
@@ -40,67 +40,67 @@ public class StatusBuilder {
 
   /**
    * Stores the name value for producing a Status object.
-   * @see #setName(java.lang.String)
+   * @see #setName
    */
   private String name;
   
   /**
    * Stores the description value for producing a Status object.
-   * @see #setDescription(java.lang.String)
+   * @see #setDescription
    */
   private String description;
   
   /**
    * Stores the duration value for producing a Status object.
-   * @see #setDuration(java.time.Duration)
+   * @see #setDuration
    */
   private Duration duration;
   
   /**
    * Stores the stackSize value for producing a Status object.
-   * @see #setStackSize(int)
+   * @see #setStackSize
    */
   private int stackSize;
   
   /**
    * Stores the stacks value for producing a Status object.
-   * @see #setStackable(boolean)
+   * @see #setStackable
    */
   private boolean stackable;
   
   /**
    * Stores the stunning value for producing a Status object.
-   * @see #setStunning(boolean)
+   * @see #setStunning
    */
   private boolean stunning;
   
   /**
    * Stores the defeating value for producing a Status object.
-   * @see #setDefeating(boolean)
+   * @see #setDefeating
    */
   private boolean defeating;
   
   /**
    * Stores the hidden value for producing a Status object.
-   * @see #setHidden(boolean)
+   * @see #setHidden
    */
   private boolean hidden;
   
   /**
    * Stores the applyCondition value for producing a Status object.
-   * @see #setApplyCondition(java.util.function.Predicate)
+   * @see #setApplyCondition
    */
   private Predicate<Fighter> applyCondition;
   
   /**
    * Stores the removeCondition value for producing a Status object.
-   * @see #setRemoveCondition(java.util.function.Predicate)
+   * @see #setRemoveCondition
    */
   private Predicate<Fighter> removeCondition;
   
   /**
    * Stores the listeners value for producing a Status object.
-   * @see #addListener(battle.StatusHandler)
+   * @see #addListener
    */
   private final List<StatusHandler> listeners;
 
@@ -108,7 +108,7 @@ public class StatusBuilder {
    * Instantiates the object with the name of the {@link Status} to be built.
    * Passing a {@code null} value to the constructor will throw an {@link
    * IllegalArgumentException}.
-   * @param name see {@see #setName(java.lang.String)}
+   * @param name see {@see #setName}
    */
   public StatusBuilder(String name) {
     if (name == null) {
@@ -318,7 +318,7 @@ public class StatusBuilder {
   /**
    * Adds to the list of {@link StatusHandler} objects that are called during
    * appropriate events in the Status object.
-   * @param  listener object to handle events.
+   * @param listener object to handle events.
    * @return this object.
    */
   public StatusBuilder addListener(StatusHandler listener) {
@@ -332,7 +332,7 @@ public class StatusBuilder {
   /**
    * Removes a listener from the list of {@link StatusHandler} objects that are
    * called during appropriate events in the Status object.
-   * @param  listener the object to be removed.
+   * @param listener the object to be removed.
    * @return true if the object was successfully removed.
    * @see #addListener(battle.StatusHandler)
    */

--- a/src/battle/StatusBuilder.java
+++ b/src/battle/StatusBuilder.java
@@ -40,67 +40,67 @@ public class StatusBuilder {
 
   /**
    * Stores the name value for producing a Status object.
-   * @see battle.Status Status.name
+   * @see #setName(java.lang.String)
    */
   private String name;
   
   /**
    * Stores the description value for producing a Status object.
-   * @see battle.Status Status.description
+   * @see #setDescription(java.lang.String)
    */
   private String description;
   
   /**
    * Stores the duration value for producing a Status object.
-   * @see battle.Status Status.duration
+   * @see #setDuration(java.time.Duration)
    */
   private Duration duration;
   
   /**
    * Stores the stackSize value for producing a Status object.
-   * @see battle.Status Status.stackSize
+   * @see #setStackSize(int)
    */
   private int stackSize;
   
   /**
    * Stores the stacks value for producing a Status object.
-   * @see battle.Status Status.stacks
+   * @see #setStackable(boolean)
    */
-  private boolean stacks;
+  private boolean stackable;
   
   /**
-   * Stores the stuns value for producing a Status object.
-   * @see battle.Status Status.stuns
+   * Stores the stunning value for producing a Status object.
+   * @see #setStunning(boolean)
    */
-  private boolean stuns;
+  private boolean stunning;
   
   /**
-   * Stores the defeats value for producing a Status object.
-   * @see battle.Status Status.defeats
+   * Stores the defeating value for producing a Status object.
+   * @see #setDefeating(boolean)
    */
-  private boolean defeats;
+  private boolean defeating;
   
   /**
    * Stores the hidden value for producing a Status object.
-   * @see battle.Status Status.hidden
+   * @see #setHidden(boolean)
    */
   private boolean hidden;
   
   /**
    * Stores the applyCondition value for producing a Status object.
-   * @see battle.Status Status.applyCondition
+   * @see #setApplyCondition(java.util.function.Predicate)
    */
   private Predicate<Fighter> applyCondition;
   
   /**
    * Stores the removeCondition value for producing a Status object.
-   * @see battle.Status Status.removeCondition
+   * @see #setRemoveCondition(java.util.function.Predicate)
    */
   private Predicate<Fighter> removeCondition;
   
   /**
    * Stores the listeners value for producing a Status object.
-   * @see battle.Status Status.listeners
+   * @see #addListener(battle.StatusHandler)
    */
   private final List<StatusHandler> listeners;
 
@@ -108,7 +108,7 @@ public class StatusBuilder {
    * Instantiates the object with the name of the {@link Status} to be built.
    * Passing a {@code null} value to the constructor will throw an {@link
    * IllegalArgumentException}.
-   * @param name name value for producing a Status object.
+   * @param name see {@see #setName(java.lang.String)}
    */
   public StatusBuilder(String name) {
     if (name == null) {
@@ -118,9 +118,9 @@ public class StatusBuilder {
     this.description = "";
     this.duration = Duration.ZERO;
     this.stackSize = 1;
-    this.stacks = true;
-    this.stuns = false;
-    this.defeats = false;
+    this.stackable = true;
+    this.stunning = false;
+    this.defeating = false;
     this.hidden = false;
     this.applyCondition = a -> true;
     this.removeCondition = a -> true;
@@ -135,16 +135,17 @@ public class StatusBuilder {
    * @return new Status object built with the values set in this builder object.
    */
   public Status build() {
-    return new Status(name, description, duration, stackSize, stacks, stuns,
-        defeats, hidden, applyCondition, removeCondition, listeners);
+    return new Status(name, description, duration, stackSize, stackable,
+        stunning, defeating, hidden, applyCondition, removeCondition,
+        listeners);
   }
 
   /**
-   * @param name name value for producing a Status object. There is no default
-   * value. Initialization of the StatusBuilder object requires a non-null name
-   * value.
-   * @return this.
-   * @see battle.Status Status.name
+   * Sets the name that identifies the status to be built from unrelated {@link
+   * Status} objects. Attempting to set the value as {@code null} will throw an
+   * {@link IllegalArgumentException}. There is no default value.
+   * @param name name of a status.
+   * @return this object.
    */
   public StatusBuilder setName(String name) {
     if (name == null) {
@@ -155,10 +156,13 @@ public class StatusBuilder {
   }
 
   /**
-   * @param description description value for producing a Status object. The
-   * default value is an empty string.
-   * @return this.
-   * @see battle.Status Status.description
+   * Sets the description of the status to be built and how it is intended to
+   * interact with {@link Fighter} objects it is applied to, as well as its
+   * interactions with other {@link Status} objects on the same fighter.
+   * Attempting to initiate the value as {@code null} will throw an {@link
+   * IllegalArgumentException}. The default value is an empty string.
+   * @param description description of a status.
+   * @return this object.
    */
   public StatusBuilder setDescription(String description) {
     if (description == null) {
@@ -169,10 +173,13 @@ public class StatusBuilder {
   }
 
   /**
-   * @param duration duration value for producing a Status object. The default
-   * value is a Duration object of ZERO.
-   * @return this.
-   * @see battle.Status Status.duration
+   * Sets the time before this status expires once it is applied. Zero means the
+   * status has an instant duration and should expire as soon as it is applied.
+   * Less then zero means duration is infinite. Attempting to initiate the value
+   * as {@code null} will throw an {@link IllegalArgumentException}. The default
+   * value is instant ({@link Duration#ZERO ZERO}).
+   * @param duration the time until the status expires.
+   * @return this object.
    */
   public StatusBuilder setDuration(Duration duration) {
     if (duration == null) {
@@ -183,10 +190,10 @@ public class StatusBuilder {
   }
 
   /**
-   * Sets this so that the status built would be marked for removal immediately
-   * after being applied. This is a convenience method for setting the duration
-   * value to ZERO.
-   * @return this.
+   * Sets the status to be built so that it would be marked for removal
+   * immediately after being applied. This is a convenience method for setting
+   * the duration value to {@link Duration#ZERO ZERO}.
+   * @return this object.
    */
   public StatusBuilder setAsInstant() {
     this.duration = Duration.ZERO;
@@ -194,10 +201,10 @@ public class StatusBuilder {
   }
   
   /**
-   * Sets this so that the status built could not expire due to the passing of
-   * time. This is a convenience method for setting the duration value to one
-   * negative second.
-   * @return this.
+   * Sets this so that the status to be built can not expire due to the passing
+   * of time. This is a convenience method for setting the duration value to
+   * {@code -1} second.
+   * @return this object.
    */
   public StatusBuilder setAsInfinite() {
     this.duration = Duration.ofSeconds(-1);
@@ -205,10 +212,11 @@ public class StatusBuilder {
   }
   
   /**
-   * @param stackSize stackSize value for producing a Status object. The default
-   * value is 1.
-   * @return this.
-   * @see battle.Status Status.stackSize
+   * Sets the current number of stacks. Attempting to initiate the value as less
+   * then {@code 1} will throw an {@link IllegalArgumentException}. The default
+   * value is {@code 1}.
+   * @param stackSize the size of the stack.
+   * @return this object.
    */
   public StatusBuilder setStackSize(int stackSize) {
     if (stackSize < 1) {
@@ -219,35 +227,41 @@ public class StatusBuilder {
   }
 
   /**
-   * @param stacks stacks value for producing a Status object. The default value
-   * is {@code true}.
-   * @return this.
-   * @see battle.Status Status.stacks
+   * Sets the status to be built so that it can have a stack size greater then
+   * {@code 1}. The default value is {@code true}.
+   * @param stackable allows the status to stack when {@code true}
+   * @return this object.
    */
-  public StatusBuilder setStackable(boolean stacks) {
-    this.stacks = stacks;
+  public StatusBuilder setStackable(boolean stackable) {
+    this.stackable = stackable;
     return this;
   }
 
   /**
-   * @param stuns stuns value for producing a Status object. The default value
-   * is {@code false}.
-   * @return this.
-   * @see battle.Status Status.stuns
+   * Sets the status to be built so that it can stun the fighter it is applied
+   * to. Stunned fighters do not decrement their skill cooldowns or execute
+   * skills for non-stunbreak skills. The default value is {@code false}.
+   * @param stunning allows the status to stun when {@code true}.
+   * @return this object.
+   * @see SkillBuilder#setStunBreak(boolean)
    */
-  public StatusBuilder setStuning(boolean stuns) {
-    this.stuns = stuns;
+  public StatusBuilder setStunning(boolean stunning) {
+    this.stunning = stunning;
     return this;
   }
 
   /**
-   * @param defeats defeats value for producing a Status object. The default
-   * value is {@code false}.
-   * @return this.
-   * @see battle.Status Status.defeats
+   * Sets the status to be built to that it can defeat the fighter it is applied
+   * to. Defeated {@link Fighter} objects allow their team to lose a battle if
+   * all other ally fighters are also defeated. Defeated fighters do not
+   * decrement their skill cooldowns or execute skills for non-deathless skills.
+   * The default value is {@code false}.
+   * @param defeats allows the status to defeat when {@code true}.
+   * @return this object.
+   * @see SkillBuilder#setDeathless(boolean)
    */
   public StatusBuilder setDefeating(boolean defeats) {
-    this.defeats = defeats;
+    this.defeating = defeats;
     return this;
   }
 


### PR DESCRIPTION
Moving most of the exposition about Status variables to the set methods of the StatusBuilder class. This moves the valuable comments to public members and away from private fields. In turn, private fields in Status and StatusBuilder, as well as getters in the Status will link to the StatusBuilder setters when appropriate in order to minimize duplication of said exposition.
